### PR TITLE
Fix mismatched backtick in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ fabsim localhost fetch_results
 
 #### Running an ensemble of simulations
 
-The FabSIM `neso_ensemble` task runs a series of FabSIM jobs taking a `SWEEP' directory as its primary input.
+The FabSIM `neso_ensemble` task runs a series of FabSIM jobs taking a `SWEEP` directory as its primary input.
 This `SWEEP` directory contains any number of subdirectories, each containing a conditions and mesh file for individual NESO jobs.
 
 A utility script [`utils/make_sweep_dir.py`](https://github.com/UCL/FabNESO/blob/main/utils/make_sweep_dir.py) is provided to automatically build this sweep directory and encode the input conditions files with templated parameters selected by the user.


### PR DESCRIPTION
Fixes a inline code formatted segment closed with a single quotation mark rather than backtick (I think I probably introduced this with one of my suggested changes in #14 🙈).