### PR TITLE
Refactoring ensemble tools

### DIFF
--- a/FabNESO/ensemble_tools.py
+++ b/FabNESO/ensemble_tools.py
@@ -107,15 +107,15 @@ def create_dict_sweep(
         indices_iterator(n_dirs, len(parameter_grids)),
         strict=True,
     ):
-        directory_name = return_directory_name(parameter_values, indices)
+        directory_name = return_directory_name(list(parameter_values.keys()), indices)
         directory_path = Path(sweep_path) / "SWEEP" / directory_name
         shutil.copytree(copy_dir, directory_path)
         edit_parameters(directory_path / edit_file, parameter_values)
 
 
-def return_directory_name(parameter_values: dict, indices: tuple[int, ...]) -> str:
+def return_directory_name(parameter_names: list[str], indices: tuple[int, ...]) -> str:
     """Return the directory name given parameter names and indices."""
-    return "-".join(f"{k}_{i}" for k, i in zip(parameter_values, indices, strict=True))
+    return "-".join(f"{k}_{i}" for k, i in zip(parameter_names, indices, strict=True))
 
 
 def list_parameter_values(conditions_file: Path, parameter_name: str) -> list[str]:

--- a/FabNESO/ensemble_tools.py
+++ b/FabNESO/ensemble_tools.py
@@ -78,6 +78,11 @@ def _product_dict(input_dict: dict) -> Iterator[dict]:
         yield dict(zip(keys, values, strict=True))
 
 
+def indices_iterator(n_dirs: int, n_parameters: int) -> Iterator[tuple[Any, ...]]:
+    """Create an iterator for the indices of the dictionary sweep."""
+    yield from itertools.product(*(range(n_dirs),) * n_parameters)
+
+
 def create_dict_sweep(
     *,
     sweep_path: Path,
@@ -99,7 +104,7 @@ def create_dict_sweep(
     # Compute Cartesian products of all parameter value combinations plus grid indices
     for parameter_values, indices in zip(
         _product_dict(parameter_grids),
-        itertools.product(*(range(n_dirs),) * len(parameter_dict)),
+        indices_iterator(n_dirs, len(parameter_grids)),
         strict=True,
     ):
         directory_name = return_directory_name(parameter_values, indices)

--- a/FabNESO/ensemble_tools.py
+++ b/FabNESO/ensemble_tools.py
@@ -6,7 +6,7 @@ import itertools
 import re
 import shutil
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 from xml.etree import ElementTree
 
 if TYPE_CHECKING:
@@ -78,7 +78,7 @@ def _product_dict(input_dict: dict) -> Iterator[dict]:
         yield dict(zip(keys, values, strict=True))
 
 
-def indices_iterator(n_dirs: int, n_parameters: int) -> Iterator[tuple[Any, ...]]:
+def indices_iterator(n_dirs: int, n_parameters: int) -> Iterator[tuple[int, ...]]:
     """Create an iterator for the indices of the dictionary sweep."""
     yield from itertools.product(*(range(n_dirs),) * n_parameters)
 
@@ -113,7 +113,7 @@ def create_dict_sweep(
         edit_parameters(directory_path / edit_file, parameter_values)
 
 
-def return_directory_name(parameter_values: dict, indices: tuple[Any, ...]) -> str:
+def return_directory_name(parameter_values: dict, indices: tuple[int, ...]) -> str:
     """Return the directory name given parameter names and indices."""
     return "-".join(f"{k}_{i}" for k, i in zip(parameter_values, indices, strict=True))
 

--- a/FabNESO/ensemble_tools.py
+++ b/FabNESO/ensemble_tools.py
@@ -6,7 +6,7 @@ import itertools
 import re
 import shutil
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from xml.etree import ElementTree
 
 if TYPE_CHECKING:
@@ -102,12 +102,15 @@ def create_dict_sweep(
         itertools.product(*(range(n_dirs),) * len(parameter_dict)),
         strict=True,
     ):
-        directory_name = "-".join(
-            f"{k}_{i}" for k, i in zip(parameter_values, indices, strict=True)
-        )
+        directory_name = return_directory_name(parameter_values, indices)
         directory_path = Path(sweep_path) / "SWEEP" / directory_name
         shutil.copytree(copy_dir, directory_path)
         edit_parameters(directory_path / edit_file, parameter_values)
+
+
+def return_directory_name(parameter_values: dict, indices: tuple[Any, ...]) -> str:
+    """Return the directory name given parameter names and indices."""
+    return "-".join(f"{k}_{i}" for k, i in zip(parameter_values, indices, strict=True))
 
 
 def list_parameter_values(conditions_file: Path, parameter_name: str) -> list[str]:

--- a/FabNESO/make_sweep_dir.py
+++ b/FabNESO/make_sweep_dir.py
@@ -73,7 +73,7 @@ def main() -> None:
         # Use the dict to create a sweep directory
         create_dict_sweep(
             sweep_path=args.sweep_path,
-            n_divs=args.n_divs,
+            n_dirs=args.n_divs,
             destructive=args.destructive,
             copy_dir=args.copy_dir,
             edit_file=args.edit_file,

--- a/FabNESO/make_sweep_dir.py
+++ b/FabNESO/make_sweep_dir.py
@@ -21,7 +21,7 @@ def main() -> None:
         default=Path(__file__).parent.parent / "config_files" / "two_stream_ensemble",
     )
     parser.add_argument(
-        "--n_divs",
+        "--n_dirs",
         help="Number of divisions in grid for each parameter",
         type=int,
         default=5,
@@ -73,7 +73,7 @@ def main() -> None:
         # Use the dict to create a sweep directory
         create_dict_sweep(
             sweep_path=args.sweep_path,
-            n_dirs=args.n_divs,
+            n_dirs=args.n_dirs,
             destructive=args.destructive,
             copy_dir=args.copy_dir,
             edit_file=args.edit_file,
@@ -83,7 +83,7 @@ def main() -> None:
     elif args.para_to_template != "":
         create_dir_tree(
             sweep_path=args.sweep_path,
-            n_dirs=args.n_divs,
+            n_dirs=args.n_dirs,
             destructive=args.destructive,
             copy_dir=args.copy_dir,
             edit_file=args.edit_file,

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ A utility script [`FabNESO/make_sweep_dir.py`](https://github.com/UCL/FabNESO/bl
 The script takes the following input parameters (see also output of passing `--help` option):
 
 - `--sweep_path` : a path that will act as the SWEEP directory (default = `$FABSIM3_HOME/plugins/FabNESO/config_files/two_stream_ensemble`),
-- `--n_divs` : Number of divisions in grid for each parameter (default = `5`),
+- `--n_dirs` : Number of divisions in grid for each parameter (default = `5`),
 - `--destructive` : Deletes the previous tree if it already exists (default = `False`),
 - `--copy_dir` : Copy contents of this dir to each sweep dir (default = `$FABSIM3_HOME/plugins/FabNESO/config_files/two_stream`),
 - `--edit_file`: Template a parameter in this file (default = `conditions.xml`).
@@ -109,7 +109,7 @@ To template a single parameter, the following three command line arguments shoul
 An example use to template the `particle_initial_velocity` parameter for 4 values between 0.1 and 2.0 using the the two_stream example files would therefore be:
 
 ```
-python -m FabNESO.make_sweep_dir --para_to_template="particle_initial_velocity" --scan_min=0.1 --scan_max=2.0 --n_divs=4
+python -m FabNESO.make_sweep_dir --para_to_template="particle_initial_velocity" --scan_min=0.1 --scan_max=2.0 --n_dirs=4
 ```
 
 The script can also template an arbitrary number of parameters in the conditions file using the following command line argument:
@@ -119,7 +119,7 @@ The script can also template an arbitrary number of parameters in the conditions
 To template both the above `particle_initial_velocity` and the `particle_charge_density` of the simulation between 102 and 109, run the following command:
 
 ```
-python -m FabNESO.make_sweep_dir --parameter_dict="{'particle_initial_velocity': [0.1,2.0], 'particle_charge_density': [102,109]}" --n_divs=4
+python -m FabNESO.make_sweep_dir --parameter_dict="{'particle_initial_velocity': [0.1,2.0], 'particle_charge_density': [102,109]}" --n_dirs=4
 ```
 
 This will create 16 directories in the `config_files/two_stream_ensemble` for the combination of these scans.

--- a/tests/test_ensemble_tools.py
+++ b/tests/test_ensemble_tools.py
@@ -52,6 +52,30 @@ def _check_parameter_in_conditions(
     return (n_equals, n_different)
 
 
+def test_list_parameter_values() -> None:
+    """Test the list_parameter_values method in ensemble_tools."""
+    conditions_file = (
+        Path(__file__).parents[1] / "config_files" / "two_stream" / "conditions.xml"
+    )
+    parameter_values = list_parameter_values(
+        conditions_file, "particle_initial_velocity"
+    )
+    # Check that we only find one instance
+    assert len(parameter_values) == 1
+    # Check the default parameter value
+    original_value = 1.0
+    assert float(parameter_values[0]) == original_value
+    # Test a fake parameter
+    parameter_values = list_parameter_values(conditions_file, "fake_parameter_not_real")
+    assert len(parameter_values) == 0
+    # Test raise a ValueError when using an incorrect xml file
+    with pytest.raises(ValueError, match=r".*Failed to find CONDITIONS.*"):
+        parameter_values = list_parameter_values(
+            Path(__file__).parents[1] / "config_files" / "two_stream" / "mesh.xml",
+            "particle_initial_velocity",
+        )
+
+
 def test_check_parameter_in_conditions(tmp_path: Path) -> None:
     """Test the private xml parser method of this class."""
     parameter_to_test = "particle_initial_velocity"

--- a/tests/test_ensemble_tools.py
+++ b/tests/test_ensemble_tools.py
@@ -294,7 +294,7 @@ def test_calculate_parameter_value(n_dirs: int, scan_range: list[float]) -> None
     ],
 )
 def test_return_directory_name(n_dirs: int, parameter_list: dict) -> None:
-    """Test the return_directory_name method."""
+    """Test the return_directory_name function."""
     directory_names = []
     # Create a dummy set of indices based on n_dirs
     for indices in indices_iterator(n_dirs, len(parameter_list)):
@@ -313,7 +313,7 @@ def test_return_directory_name(n_dirs: int, parameter_list: dict) -> None:
 @pytest.mark.parametrize("n_dirs", [1, 3, 7])
 @pytest.mark.parametrize("n_parameters", [1, 2, 5, 7])
 def test_indices_iterator(n_dirs: int, n_parameters: int) -> None:
-    """The the indices_iterator from the ensemble_tools."""
+    """Test the indices_iterator from the ensemble_tools."""
     indices_list = []
     for indices in indices_iterator(n_dirs, n_parameters):
         assert len(indices) == n_parameters

--- a/tests/test_ensemble_tools.py
+++ b/tests/test_ensemble_tools.py
@@ -279,3 +279,32 @@ def test_calculate_parameter_value(n_dirs: int, scan_range: list[float]) -> None
     assert len(parameter_values) == n_unique_entries
     for value in parameter_values:
         assert min(scan_range) <= value <= max(scan_range)
+
+
+@pytest.mark.parametrize("n_dirs", [1, 3, 100])
+@pytest.mark.parametrize(
+    "parameter_list",
+    [
+        {"particle_initial_velocity": [], "particle_charge_density": []},
+        {
+            "particle_initial_velocity": [],
+            "particle_charge_density": [],
+            "particle_number_density": [],
+        },
+    ],
+)
+def test_return_directory_name(n_dirs: int, parameter_list: dict) -> None:
+    """Test the return_directory_name method."""
+    directory_names = []
+    # Create a dummy set of indices based on n_dirs
+    for indices in itertools.product(*(range(n_dirs),) * len(parameter_list)):
+        dir_name = return_directory_name(parameter_list, indices)
+        # Check that each parameter only appears once in the directory name
+        for parameter in parameter_list:
+            assert dir_name.count(parameter) == 1
+        directory_names.append(dir_name)
+    # Check we've made the correct number of directories
+    assert len(directory_names) == n_dirs ** len(parameter_list)
+    # Check that we've made unique directories
+    n_unique_dirs = len(set(directory_names))
+    assert len(directory_names) == n_unique_dirs

--- a/tests/test_ensemble_tools.py
+++ b/tests/test_ensemble_tools.py
@@ -232,3 +232,27 @@ def test_create_dict_sweep(
             )
             assert n_equal_in_value == 1
             assert n_different_in_value == 0
+
+
+@pytest.mark.parametrize("n_dirs", [1, 3, 100])
+@pytest.mark.parametrize(
+    "scan_range",
+    [
+        [1.0, 3.0],
+        [10000, 20000],
+        [5.0, 4.0],
+    ],
+)
+def test_calculate_parameter_value(n_dirs: int, scan_range: list[float]) -> None:
+    """Tests the calculate_parameter_value method of ensemble_tools."""
+    parameter_values = [
+        calculate_parameter_value(n_dirs, scan_range[0], scan_range[1], i)
+        for i in range(n_dirs)
+    ]
+    # Check the returned list has the correct number of entries
+    assert len(parameter_values) == n_dirs
+    # Check the values in the generated list are unique
+    n_unique_entries = len(set(parameter_values))
+    assert len(parameter_values) == n_unique_entries
+    for value in parameter_values:
+        assert min(scan_range) <= value <= max(scan_range)

--- a/tests/test_ensemble_tools.py
+++ b/tests/test_ensemble_tools.py
@@ -13,6 +13,7 @@ from FabNESO.ensemble_tools import (
     create_dir_tree,
     edit_parameters,
     list_parameter_values,
+    return_directory_name,
 )
 
 
@@ -232,9 +233,7 @@ def test_create_dict_sweep(
 
     # Loop through the directories and check the conditions file
     for indices in itertools.product(*(range(n_dirs),) * len(parameter_dict)):
-        directory_name = "-".join(
-            f"{k}_{i}" for k, i in zip(parameter_dict, indices, strict=True)
-        )
+        directory_name = return_directory_name(parameter_dict, indices)
         this_dir = sweep_path / "SWEEP" / directory_name
 
         # Check the directory exists

--- a/tests/test_ensemble_tools.py
+++ b/tests/test_ensemble_tools.py
@@ -1,6 +1,5 @@
 """Tests for the ensemble_tools utilities."""
 
-import itertools
 import shutil
 from pathlib import Path
 from typing import TypedDict
@@ -12,6 +11,7 @@ from FabNESO.ensemble_tools import (
     create_dict_sweep,
     create_dir_tree,
     edit_parameters,
+    indices_iterator,
     list_parameter_values,
     return_directory_name,
 )
@@ -232,7 +232,7 @@ def test_create_dict_sweep(
     assert len(list((sweep_path / "SWEEP").iterdir())) == n_total_directories
 
     # Loop through the directories and check the conditions file
-    for indices in itertools.product(*(range(n_dirs),) * len(parameter_dict)):
+    for indices in indices_iterator(n_dirs, len(parameter_dict)):
         directory_name = return_directory_name(parameter_dict, indices)
         this_dir = sweep_path / "SWEEP" / directory_name
 
@@ -297,7 +297,7 @@ def test_return_directory_name(n_dirs: int, parameter_list: dict) -> None:
     """Test the return_directory_name method."""
     directory_names = []
     # Create a dummy set of indices based on n_dirs
-    for indices in itertools.product(*(range(n_dirs),) * len(parameter_list)):
+    for indices in indices_iterator(n_dirs, len(parameter_list)):
         dir_name = return_directory_name(parameter_list, indices)
         # Check that each parameter only appears once in the directory name
         for parameter in parameter_list:
@@ -308,3 +308,16 @@ def test_return_directory_name(n_dirs: int, parameter_list: dict) -> None:
     # Check that we've made unique directories
     n_unique_dirs = len(set(directory_names))
     assert len(directory_names) == n_unique_dirs
+
+
+@pytest.mark.parametrize("n_dirs", [1, 3, 7])
+@pytest.mark.parametrize("n_parameters", [1, 2, 5, 7])
+def test_indices_iterator(n_dirs: int, n_parameters: int) -> None:
+    """The the indices_iterator from the ensemble_tools."""
+    indices_list = []
+    for indices in indices_iterator(n_dirs, n_parameters):
+        assert len(indices) == n_parameters
+        indices_list.append(indices)
+    assert len(indices_list) == n_dirs**n_parameters
+    n_unique_indices = len(set(indices_list))
+    assert n_unique_indices == len(indices_list)

--- a/tests/test_ensemble_tools.py
+++ b/tests/test_ensemble_tools.py
@@ -233,7 +233,7 @@ def test_create_dict_sweep(
 
     # Loop through the directories and check the conditions file
     for indices in indices_iterator(n_dirs, len(parameter_dict)):
-        directory_name = return_directory_name(parameter_dict, indices)
+        directory_name = return_directory_name(list(parameter_dict.keys()), indices)
         this_dir = sweep_path / "SWEEP" / directory_name
 
         # Check the directory exists
@@ -285,15 +285,15 @@ def test_calculate_parameter_value(n_dirs: int, scan_range: list[float]) -> None
 @pytest.mark.parametrize(
     "parameter_list",
     [
-        {"particle_initial_velocity": [], "particle_charge_density": []},
-        {
-            "particle_initial_velocity": [],
-            "particle_charge_density": [],
-            "particle_number_density": [],
-        },
+        ["particle_initial_velocity", "particle_charge_density"],
+        [
+            "particle_initial_velocity",
+            "particle_charge_density",
+            "particle_number_density",
+        ],
     ],
 )
-def test_return_directory_name(n_dirs: int, parameter_list: dict) -> None:
+def test_return_directory_name(n_dirs: int, parameter_list: list[str]) -> None:
     """Test the return_directory_name method."""
     directory_names = []
     # Create a dummy set of indices based on n_dirs


### PR DESCRIPTION
Resolves #25 and #26 , refactoring the calculation of parameter grid values and directory names, and including unit tests for these new methods.

Also refactors out the xml parser from the tests, so that this method can be used later in the VBMC code.

Regarding the refactoring of calculate_parameter_value (issue #25); I considered making the method return an iterator, but the logic for the dictionary sweep methods didn't seem compatible with this, so I left it instead as a direct calculation of the parameter value at a point instead. Open to alternative suggestions on that, though.