### PR TITLE
Extending the ensemble tools and task to allow variable parameter grids, and command line interaction

### DIFF
--- a/FabNESO/ensemble_tools.py
+++ b/FabNESO/ensemble_tools.py
@@ -104,10 +104,9 @@ def create_dict_sweep(
         for key, (low, high, n_dir_parameter) in parameter_dict.items()
     }
     # Compute Cartesian products of all parameter value combinations plus grid indices
-    [n_dir[2] for n_dir in parameter_dict.values()]
     for parameter_values, indices in zip(
         _product_dict(parameter_grids),
-        indices_iterator([n_dirs[2] for n_dirs in parameter_dict.values()]),
+        indices_iterator([n_dir for *_, n_dir in parameter_dict.values()]),
         strict=True,
     ):
         directory_name = return_directory_name(list(parameter_values.keys()), indices)

--- a/FabNESO/make_sweep_dir.py
+++ b/FabNESO/make_sweep_dir.py
@@ -4,7 +4,7 @@ import argparse
 from ast import literal_eval
 from pathlib import Path
 
-from .ensemble_tools import create_dict_sweep, create_dir_tree
+from FabNESO.ensemble_tools import create_dict_sweep, create_dir_tree
 
 
 def main() -> None:
@@ -70,10 +70,14 @@ def main() -> None:
         if not isinstance(parameter_dict, dict):
             msg = "Did not receive a dict as input for parameter_dict"
             raise ValueError(msg)
+        # If we define n_dirs in the command line argument, override any
+        # dict parameters we didn't assign n_dirs to
+        for _parameter, values in parameter_dict.items():
+            if len(values) < 3:  # noqa: PLR2004
+                values.append(args.n_dirs)
         # Use the dict to create a sweep directory
         create_dict_sweep(
             sweep_path=args.sweep_path,
-            n_dirs=args.n_dirs,
             destructive=args.destructive,
             copy_dir=args.copy_dir,
             edit_file=args.edit_file,

--- a/FabNESO/make_sweep_dir.py
+++ b/FabNESO/make_sweep_dir.py
@@ -4,7 +4,7 @@ import argparse
 from ast import literal_eval
 from pathlib import Path
 
-from FabNESO.ensemble_tools import create_dict_sweep, create_dir_tree
+from .ensemble_tools import create_dict_sweep, create_dir_tree
 
 
 def main() -> None:
@@ -72,7 +72,7 @@ def main() -> None:
             raise ValueError(msg)
         # If we define n_dirs in the command line argument, override any
         # dict parameters we didn't assign n_dirs to
-        for _parameter, values in parameter_dict.items():
+        for values in parameter_dict.values():
             if len(values) < 3:  # noqa: PLR2004
                 values.append(args.n_dirs)
         # Use the dict to create a sweep directory

--- a/FabNESO/tasks.py
+++ b/FabNESO/tasks.py
@@ -15,7 +15,7 @@ except ImportError:
     from base import fab
 
 
-from .ensemble_tools import edit_parameters
+from .ensemble_tools import create_dict_sweep, edit_parameters
 
 fab.add_local_paths("FabNESO")
 
@@ -81,6 +81,7 @@ def neso_ensemble(
     solver: str = "Electrostatic2D3V",
     conditions_file_name: str = "conditions.xml",
     mesh_file_name: str = "mesh.xml",
+    **parameter_scans: str,
 ) -> None:
     """
     Run ensemble of NESO solver instances.
@@ -90,16 +91,47 @@ def neso_ensemble(
         solver: Which NESO solver to use.
         conditions_file_name: Name of conditions XML file in configuration directory.
         mesh_file_name: Name of mesh XML in configuration directory.
+        parameter_scans is a set of parameters to sweep over. A slash separated list of
+        lower bound, upper bound, and steps.
     """
-    path_to_config = fab.find_config_file_path(config)
-    sweep_dir = str(Path(path_to_config) / "SWEEP")
-    fab.update_environment(
-        {
-            "script": "neso",
-            "neso_solver": solver,
-            "neso_conditions_file": conditions_file_name,
-            "neso_mesh_file": mesh_file_name,
-        }
+    path_to_config = Path(fab.find_config_file_path(config))
+    temporary_context: TemporaryDirectory | nullcontext = (
+        TemporaryDirectory(prefix=f"{config}_", dir=path_to_config.parent)
+        if parameter_scans != {}
+        else nullcontext()
     )
-    fab.with_config(config)
-    fab.run_ensemble(config, sweep_dir)
+    with temporary_context as temporary_config_directory:
+        if parameter_scans != {}:
+            temporary_config_path = Path(temporary_config_directory)
+            # Because FabSIM is a bit weird with commas, build the dict here
+            parameter_scan_dict = {
+                parameter: (
+                    float(values.split("/")[0]),
+                    float(values.split("/")[1]),
+                    int(values.split("/")[2]),
+                )
+                for parameter, values in parameter_scans.items()
+            }
+            create_dict_sweep(
+                sweep_path=temporary_config_path,
+                destructive=False,
+                copy_dir=path_to_config,
+                edit_file=conditions_file_name,
+                parameter_dict=parameter_scan_dict,
+            )
+
+            # switch our config to the new tmp ones
+            config = temporary_config_path.name
+            path_to_config = temporary_config_path
+
+        sweep_dir = str(path_to_config / "SWEEP")
+        fab.update_environment(
+            {
+                "script": "neso",
+                "neso_solver": solver,
+                "neso_conditions_file": conditions_file_name,
+                "neso_mesh_file": mesh_file_name,
+            }
+        )
+        fab.with_config(config)
+        fab.run_ensemble(config, sweep_dir)

--- a/FabNESO/tasks.py
+++ b/FabNESO/tasks.py
@@ -99,7 +99,7 @@ def neso_ensemble(
         solver: Which NESO solver to use.
         conditions_file_name: Name of conditions XML file in configuration directory.
         mesh_file_name: Name of mesh XML in configuration directory.
-        **parameter_scans: The set of parameters to sweep over. A slash separated list
+        **parameter_scans: The set of parameters to sweep over. A colon separated list
         of lower bound, upper bound, and steps.
     """
     path_to_config = Path(fab.find_config_file_path(config))
@@ -113,7 +113,7 @@ def neso_ensemble(
             temporary_config_path = Path(temporary_config_directory)
             # Because FabSIM is a bit weird with commas, build the dict here
             parameter_scan_dict = {
-                parameter: (_parse_parameter_scan_string(values, ":"))
+                parameter: _parse_parameter_scan_string(values, ":")
                 for parameter, values in parameter_scans.items()
             }
             create_dict_sweep(

--- a/FabNESO/tasks.py
+++ b/FabNESO/tasks.py
@@ -74,6 +74,14 @@ def neso(
         )
 
 
+def _parse_parameter_scan_string(
+    parameter_scan_string: str,
+    delimiter: str,
+) -> tuple[float, float, int]:
+    start, end, n_steps = parameter_scan_string.split(delimiter)
+    return float(start), float(end), int(n_steps)
+
+
 @fab.task
 @fab.load_plugin_env_vars("FabNESO")
 def neso_ensemble(
@@ -91,8 +99,8 @@ def neso_ensemble(
         solver: Which NESO solver to use.
         conditions_file_name: Name of conditions XML file in configuration directory.
         mesh_file_name: Name of mesh XML in configuration directory.
-        parameter_scans is a set of parameters to sweep over. A slash separated list of
-        lower bound, upper bound, and steps.
+        **parameter_scans: The set of parameters to sweep over. A slash separated list
+        of lower bound, upper bound, and steps.
     """
     path_to_config = Path(fab.find_config_file_path(config))
     temporary_context: TemporaryDirectory | nullcontext = (
@@ -105,11 +113,7 @@ def neso_ensemble(
             temporary_config_path = Path(temporary_config_directory)
             # Because FabSIM is a bit weird with commas, build the dict here
             parameter_scan_dict = {
-                parameter: (
-                    float(values.split("/")[0]),
-                    float(values.split("/")[1]),
-                    int(values.split("/")[2]),
-                )
+                parameter: (_parse_parameter_scan_string(values, ":"))
                 for parameter, values in parameter_scans.items()
             }
             create_dict_sweep(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "numpy",
 ]
 description = "Neptune Exploratory SOftware (NESO) plugin for FabSim3"
 dynamic = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
+    "numpy",
 ]
 description = "Neptune Exploratory SOftware (NESO) plugin for FabSim3"
 dynamic = [

--- a/tests/test_ensemble_tools.py
+++ b/tests/test_ensemble_tools.py
@@ -1,10 +1,11 @@
 """Tests for the ensemble_tools utilities."""
 
 import shutil
+from functools import reduce
+from operator import mul
 from pathlib import Path
 from typing import TypedDict
 
-import numpy as np
 import pytest
 
 from FabNESO.ensemble_tools import (
@@ -237,7 +238,7 @@ def test_create_dict_sweep(
         edit_file=edit_file,
         parameter_dict=parameter_dict,
     )
-    n_total_directories = np.prod(n_dirs[: len(parameter_dict)])
+    n_total_directories = reduce(mul, n_dirs[: len(parameter_dict)])
     # Check we make the corect number of directories
     assert len(list((sweep_path / "SWEEP").iterdir())) == n_total_directories
 
@@ -256,10 +257,8 @@ def test_create_dict_sweep(
         # Check that the parameters have been edited correctly
         for i in range(len(parameter_dict)):
             parameter = list(parameter_dict.keys())[i]
-            scan_range = parameter_dict[parameter]
-            para_value = calculate_parameter_value(
-                scan_range[2], scan_range[0], scan_range[1], indices[i]
-            )
+            low, high, n_steps = parameter_dict[parameter]
+            para_value = calculate_parameter_value(n_steps, low, high, indices[i])
             n_equal_in_value, n_different_in_value = _check_parameter_in_conditions(
                 this_dir / "conditions.xml", parameter, para_value
             )
@@ -321,7 +320,7 @@ def test_return_directory_name(n_dirs: list[int], parameter_list: list[str]) -> 
             assert dir_name.count(parameter) == 1
         directory_names.append(dir_name)
     # Check we've made the correct number of directories
-    assert len(directory_names) == np.prod(n_dirs[: len(parameter_list)])
+    assert len(directory_names) == reduce(mul, n_dirs[: len(parameter_list)])
     # Check that we've made unique directories
     n_unique_dirs = len(set(directory_names))
     assert len(directory_names) == n_unique_dirs
@@ -342,6 +341,6 @@ def test_indices_iterator(n_dirs: list[int]) -> None:
     for indices in indices_iterator(n_dirs):
         assert len(indices) == len(n_dirs)
         indices_list.append(indices)
-    assert len(indices_list) == np.prod(n_dirs)
+    assert len(indices_list) == reduce(mul, n_dirs)
     n_unique_indices = len(set(indices_list))
     assert n_unique_indices == len(indices_list)


### PR DESCRIPTION
Resolves #20, resolves #21 

`parameter_dict` in the `create_dict_sweep` function of `ensemble_tools` now includes an additional requirement of a number of steps for the sweep. In the `make_sweep_dir` script, this can either be set directly by the user when passing the input `dict` or assigned automatically with `n_dirs` if no argument is given.

This has necessitated a change to the way the iteration indices are calculated, which has been propagated throughout the `ensemble_tools` and its associated tests.

I have then also extended the `neso_ensemble` task to allow the definition of parameters to sweep directly in the command line, by calling this function in a manner similar to the original `neso` task.

A minor problem I encountered here was that even inside quotation and speech marks `FabSIM3` still splits the input argument list by commas. This means that when an argument such as `particle_initial_velocity="(0.2,2.0,5)"` is provided, `FabSIM` interprets this as `{"particle_initial_velocity": "\"(0.2"}` and discards the rest of the tuple. I couldn't find any obvious way around this, so I'm suggesting that for the command line definition of our sweep bounds the list be given with a `/` separating the parameters. This is then interpreted into the correct form inside the `neso_ensemble` task. The above example would then be: `particle_initial_velocity=0.2/2.0/5`. If that sounds acceptable, I can update the documentation to reflect this.