### PR TITLE
Update conditions files to match original NESO examples

### DIFF
--- a/config_files/2Din3D-hw/conditions.xml
+++ b/config_files/2Din3D-hw/conditions.xml
@@ -7,7 +7,7 @@
         The composite index for the domain is expected to be 0 if the mesh was generated from the included .geo file
      -->
     <EXPANSIONS>
-       <E COMPOSITE="C[0]" NUMMODES="7" TYPE="MODIFIED" FIELDS="ne,w,phi" />
+       <E COMPOSITE="C[0]" NUMMODES="6" TYPE="MODIFIED" FIELDS="ne,w,phi,ne_src" />
     </EXPANSIONS>
 
     <CONDITIONS>
@@ -28,29 +28,46 @@
 
         <PARAMETERS>
             <!-- Timestepping and output options -->
-            <P> TimeStep      = 0.00125           </P>
-            <P> NumSteps      = 20              </P>
+            <P> TimeStep      = 0.000625          </P>
+            <P> NumSteps      = 64000             </P>
             <P> TFinal        = NumSteps*TimeStep </P>
-            <P> IO_InfoSteps  = NumSteps/16     </P>
-            <P> IO_CheckSteps = NumSteps/2      </P>
-            <P> growth_rates_recording_step = NumSteps/5 </P>
+            <P> IO_InfoSteps  = NumSteps/1600     </P>
+            <P> IO_CheckSteps = NumSteps/160      </P>
             <!-- Magnetic field strength -->
             <P> Bxy      = 1.0 </P>
             <!-- d22 Coeff for Helmholtz solve -->
             <P> d22      = 0.0 </P>
             <!-- HW params -->
+            <!-- Dissipates density? -->
             <P> HW_alpha = 0.1 </P>
+            <!-- Drives turbulence?-->
             <P> HW_kappa = 3.5 </P>
             <!-- Scaling factor for ICs -->
             <P> s        = 0.5 </P>
-            <!-- No particles -->
-            <P> num_particles_total = 0 </P>
+            <!-- Neutral particle system params -->
+            <P> num_particles_per_cell            = -1            </P>
+            <P> num_particle_steps_per_fluid_step = 1             </P>
+            <P> num_particles_total               = 100000        </P>
+            <P> particle_num_write_particle_steps = IO_CheckSteps </P>
+            <P> particle_number_density           = 1e16          </P>
+            <P> particle_position_seed            = 1             </P>
+            <P> particle_thermal_velocity         = 1.0           </P>
+            <P> particle_drift_velocity           = 2.0           </P>
+            <P> particle_source_width             = 0.2           </P>
+            <!-- Temperature in eV used to compute ionisation rate -->
+            <P> Te_eV = 10.0 </P>
+            <!-- Assumed background density in SI -->
+            <P> n_bg_SI = 1e18 </P>
+            <!-- Unit conversion factors for ionisation calc -->
+            <P> t_to_SI = 2e-4 </P>
+            <P> n_to_SI = 1e17 </P>
         </PARAMETERS>
 
         <VARIABLES>
             <V ID="0"> ne  </V>
             <V ID="1"> w   </V>
             <V ID="2"> phi </V>
+            <V ID="3"> ne_src </V>
         </VARIABLES>
 
         <BOUNDARYREGIONS>
@@ -65,40 +82,47 @@
         <!-- Periodic conditions for all fields on all boundaries -->
         <BOUNDARYCONDITIONS>
             <REGION REF="0">
-                <P VAR="ne"  VALUE="[1]" />
-                <P VAR="w"   VALUE="[1]" />
-                <P VAR="phi" VALUE="[1]" />
+                <P VAR="ne"     VALUE="[1]" />
+                <P VAR="w"      VALUE="[1]" />
+                <P VAR="phi"    VALUE="[1]" />
+                <P VAR="ne_src" VALUE="[1]" />
             </REGION>
             <REGION REF="1">
-                <P VAR="ne"  VALUE="[0]" />
-                <P VAR="w"   VALUE="[0]" />
-                <P VAR="phi" VALUE="[0]" />
+                <P VAR="ne"     VALUE="[0]" />
+                <P VAR="w"      VALUE="[0]" />
+                <P VAR="phi"    VALUE="[0]" />
+                <P VAR="ne_src" VALUE="[0]" />
             </REGION>
-                <REGION REF="2">
-                <P VAR="ne"  VALUE="[3]" />
-                <P VAR="w"   VALUE="[3]" />
-                <P VAR="phi" VALUE="[3]" />
+            <REGION REF="2">
+                <P VAR="ne"     VALUE="[3]" />
+                <P VAR="w"      VALUE="[3]" />
+                <P VAR="phi"    VALUE="[3]" />
+                <P VAR="ne_src" VALUE="[3]" />
             </REGION>
             <REGION REF="3">
-                <P VAR="ne"  VALUE="[2]" />
-                <P VAR="w"   VALUE="[2]" />
-                <P VAR="phi" VALUE="[2]" />
+                <P VAR="ne"     VALUE="[2]" />
+                <P VAR="w"      VALUE="[2]" />
+                <P VAR="phi"    VALUE="[2]" />
+                <P VAR="ne_src" VALUE="[2]" />
             </REGION>
             <REGION REF="4">
-                <P VAR="ne"  VALUE="[5]" />
-                <P VAR="w"   VALUE="[5]" />
-                <P VAR="phi" VALUE="[5]" />
+                <P VAR="ne"     VALUE="[5]" />
+                <P VAR="w"      VALUE="[5]" />
+                <P VAR="phi"    VALUE="[5]" />
+                <P VAR="ne_src" VALUE="[5]" />
             </REGION>
             <REGION REF="5">
-                <P VAR="ne"  VALUE="[4]" />
-                <P VAR="w"   VALUE="[4]" />
-                <P VAR="phi" VALUE="[4]" />
+                <P VAR="ne"     VALUE="[4]" />
+                <P VAR="w"      VALUE="[4]" />
+                <P VAR="phi"    VALUE="[4]" />
+                <P VAR="ne_src" VALUE="[4]" />
             </REGION>
         </BOUNDARYCONDITIONS>
         <FUNCTION NAME="InitialConditions">
-            <E VAR="ne"  DOMAIN="0" VALUE="6*exp((-x*x-y*y)/(s*s))*sin(4*PI*z/10)" />
-            <E VAR="w"   DOMAIN="0" VALUE="(4*exp((-x*x-y*y)/(s*s))*(-s*s+x*x+y*y)/s^4)*sin(4*PI*z/10)" />
-            <E VAR="phi" DOMAIN="0" VALUE="exp(-(x*x+y*y)/(s*s))*sin(4*PI*z/10)" />
+            <E VAR="ne"  DOMAIN="0" VALUE="0" />
+            <E VAR="w"   DOMAIN="0" VALUE="0" />
+            <E VAR="phi" DOMAIN="0" VALUE="0" />
+            <E VAR="ne_src" DOMAIN="0" VALUE="0.0" />
         </FUNCTION>
     </CONDITIONS>
 </NEKTAR>

--- a/config_files/2Din3D-hw/conditions.xml
+++ b/config_files/2Din3D-hw/conditions.xml
@@ -38,9 +38,7 @@
             <!-- d22 Coeff for Helmholtz solve -->
             <P> d22      = 0.0 </P>
             <!-- HW params -->
-            <!-- Dissipates density? -->
             <P> HW_alpha = 0.1 </P>
-            <!-- Drives turbulence?-->
             <P> HW_kappa = 3.5 </P>
             <!-- Scaling factor for ICs -->
             <P> s        = 0.5 </P>
@@ -61,6 +59,8 @@
             <!-- Unit conversion factors for ionisation calc -->
             <P> t_to_SI = 2e-4 </P>
             <P> n_to_SI = 1e17 </P>
+            <!-- Turn on energy, enstrophy output -->
+            <P> growth_rates_recording_step = 1 </P>
         </PARAMETERS>
 
         <VARIABLES>

--- a/config_files/two_stream/conditions.xml
+++ b/config_files/two_stream/conditions.xml
@@ -27,7 +27,7 @@
             <P> num_particles_total = 400000 </P>
             <P> num_particles_per_cell = -1 </P>
             <P> particle_time_step = 0.001 </P>
-            <P> particle_num_time_steps = 200 </P>
+            <P> particle_num_time_steps = 1800 </P>
             <P> particle_num_write_particle_steps = 0 </P>
             <P> particle_num_write_field_energy_steps = 20 </P>
             <P> particle_num_write_field_steps = 0 </P>


### PR DESCRIPTION
Updates the example `conditions.xml` files in `config_files` to exactly (bar tab to space subsititutions) match the `two_stream` and `2Din3D-hw` examples in https://github.com/ExCALIBUR-NEPTUNE/NESO/blob/main/examples/Electrostatic2D3V/two_stream/two_stream_conditions.xml and https://github.com/ExCALIBUR-NEPTUNE/NESO/blob/main/examples/H3LAPD/2Din3D-hw/hw.xml respectively.

The current files reduced the number of simulated time steps, presumably to allow for quicker iteration when testing, and for the `2Din3D-hw` case was based on the simpler `2Din3D-hw_fluid_only` variant. As we now support overriding the parameters when running the task, I think having the conditions match the original NESO examples for consistency makes more sense, with it still possible to quickly override the parameters when running to reduce the compute time required.