### PR TITLE
Use `run_command` in template script

### DIFF
--- a/machines_FabNESO_user_example.yml
+++ b/machines_FabNESO_user_example.yml
@@ -10,4 +10,4 @@ default:
 
 localhost:
   neso_bin_dir: "change-me" # path to directory containing built NESO solver executables
-  run_command: "OMP_NUM_THREADS=1 mpirun -n $cores -map-by core -bind-to hwthread"
+  run_command: "mpirun -n $cores -map-by core -bind-to hwthread"

--- a/machines_FabNESO_user_example.yml
+++ b/machines_FabNESO_user_example.yml
@@ -1,11 +1,17 @@
-# This is the user personal configuration for job submission and execution for FabNESO plugin
-# All given variables here will be override machine settings loaded from (a) FabSim3/deploy/machines.yml and (b) FabSim3/deploy/machines_user.yml
+# This is the user configuration for job submission and execution for the FabNESO plugin
+# All given variables here will be override machine settings loaded from
+# (a) FabSim3/deploy/machines.yml and (b) FabSim3/deploy/machines_user.yml
 #
 # Here, you can find some examples for pre-defined remote machines
-# All env variable can be modified here and will overwrite setting in machines.yml and machines_user.yml
+# All env variable can be modified here and will overwrite setting in
+# machines.yml and machines_user.yml
 
 default:
 
 localhost:
-  # location of NESO on your local PC
-  neso_bin_dir: "<..>"
+  neso_bin_dir: "change-me" # path to directory containing built NESO solver executables
+  run_command: "OMP_NUM_THREADS=1 mpirun -n $cores -map-by core -bind-to hwthread"
+
+archer2:
+  neso_bin_dir: "change-me" # path to directory containing built NESO solver executables
+  run_command: "srun --distribution=block:block --hint=nomultithread"

--- a/machines_FabNESO_user_example.yml
+++ b/machines_FabNESO_user_example.yml
@@ -11,7 +11,3 @@ default:
 localhost:
   neso_bin_dir: "change-me" # path to directory containing built NESO solver executables
   run_command: "OMP_NUM_THREADS=1 mpirun -n $cores -map-by core -bind-to hwthread"
-
-archer2:
-  neso_bin_dir: "change-me" # path to directory containing built NESO solver executables
-  run_command: "srun --distribution=block:block --hint=nomultithread"

--- a/templates/neso
+++ b/templates/neso
@@ -1,6 +1,9 @@
 cd $job_results
 $run_prefix
 
+# Disable OpenMP threading to avoid over subscription when parallelising using MPI
+export OMP_NUM_THREADS=1
+
 cat << ENDOFMESSAGE
 Running NESO solver $neso_solver from $neso_bin_dir in directory $job_results
 with conditions file $neso_conditions_file and mesh file $neso_mesh_file

--- a/templates/neso
+++ b/templates/neso
@@ -1,10 +1,9 @@
-
 cd $job_results
 $run_prefix
 
+cat << ENDOFMESSAGE
+Running NESO solver $neso_solver from $neso_bin_dir in directory $job_results
+with conditions file $neso_conditions_file and mesh file $neso_mesh_file
+ENDOFMESSAGE
 
-echo "Running NESO solver $neso_solver"
-
-echo ${neso_bin_dir}$neso_solver $neso_conditions_file $neso_mesh_file
-
-${neso_bin_dir}$neso_solver $neso_conditions_file $neso_mesh_file
+$run_command $neso_bin_dir/$neso_solver $neso_conditions_file $neso_mesh_file


### PR DESCRIPTION
Updates the `templates/neso` template script to prefix the solver executable run command with the value of the `run_command` variable. This allows the user to configure a machine specific value of `run_command` to use to dispatch the solver runs on different machines. By default [on `localhost` FabSim3 defaults `run_command` to `mpirun -np $cores`](https://github.com/djgroen/FabSim3/blob/62ca215febb2ef5112a7f5a59574ae3db465a1e7/fabsim/deploy/machines.yml#L64). Here we also the default value (in the example configuration script) for `run_command` on `localhost` to ~~`"OMP_NUM_THREADS=1 mpirun -n $cores -map-by core -bind-to hwthread"` in the `machines_FabNESO_user_example.yml`, which will ensure no OpenMP multithreading is used and to  `"srun --distribution=block:block --hint=nomultithread"` on `archer2`~~ `"mpirun -n $cores -map-by core -bind-to hwthread"` in the `machines_FabNESO_user_example.yml` and export `OMP_NUM_THREADS=1` in the template script to disable threading to avoid over-subscription of CPU cores when parallelising with MPI. 

Edit: Default `archer2` run command now updated in FabSim so specification here removed.