### PR TITLE
Expose task arguments to set job resources

### DIFF
--- a/FabNESO/tasks.py
+++ b/FabNESO/tasks.py
@@ -25,7 +25,7 @@ def _try_convert_to_int_and_check_positive(value: str | int, name: str) -> int:
     try:
         value = int(value)
     except ValueError as e:
-        msg = f"{name} is not a valid an integer literal: {value}"
+        msg = f"{name} is not a valid integer literal: {value}"
         raise ValueError(msg) from e
     if value <= 0:
         msg = f"{name} must be a positive integer: {value}"
@@ -185,7 +185,7 @@ def neso_ensemble(
         solver: Which NESO solver to use.
         conditions_file_name: Name of conditions XML file in configuration directory.
         mesh_file_name: Name of mesh XML in configuration directory.
-        processes: Number of processes to run each job in ensemble on.
+        processes: Number of processes to run in each job in the ensemble.
         nodes: Number of nodes to run each job in ensemble on. Only applicable when
             running on a multi-node system.
         cpus_per_process: Number of processing units to use per process for each job in

--- a/FabNESO/tasks.py
+++ b/FabNESO/tasks.py
@@ -4,6 +4,7 @@ Task definitions for FabNESO plug-in to FabSIM software toolkit.
 Defines tasks for running simulations using Neptune Exploratory Software (NESO).
 """
 
+import re
 import shutil
 from contextlib import nullcontext
 from pathlib import Path
@@ -20,6 +21,70 @@ from .ensemble_tools import edit_parameters
 fab.add_local_paths("FabNESO")
 
 
+def _try_convert_to_int_and_check_positive(value: str | int, name: str) -> int:
+    try:
+        value = int(value)
+    except ValueError as e:
+        msg = f"{name} is not a valid an integer literal: {value}"
+        raise ValueError(msg) from e
+    if value <= 0:
+        msg = f"{name} must be a positive integer: {value}"
+        raise ValueError(msg)
+    return value
+
+
+def _check_and_process_resource_args(
+    processes: str | int,
+    nodes: str | int,
+    cpus_per_process: str | int,
+    wall_time: str,
+) -> tuple[int, int, int, str]:
+    processes = _try_convert_to_int_and_check_positive(processes, "processes")
+    nodes = _try_convert_to_int_and_check_positive(nodes, "nodes")
+    cpus_per_process = _try_convert_to_int_and_check_positive(
+        cpus_per_process, "cpus_per_process"
+    )
+    if processes % nodes != 0:
+        msg = "processes must be a multiple of nodes"
+        raise ValueError(msg)
+    wall_time = wall_time.strip()
+    match = re.match(r"^\d{1,2}:(?P<minutes>\d{1,2}):(?P<seconds>\d{1,2})$", wall_time)
+    if match is None:
+        msg = "wall_time should be of format hh:mm:ss"
+        raise ValueError(msg)
+    minutes_in_hour = seconds_in_minute = 60
+    if (
+        int(match.group("minutes")) >= minutes_in_hour
+        or int(match.group("seconds")) >= seconds_in_minute
+    ):
+        msg = "wall_time minute and second components should be in range 0 to 59"
+        raise ValueError(msg)
+    return processes, nodes, cpus_per_process, wall_time
+
+
+def _create_job_args_dict(
+    solver: str,
+    conditions_file_name: str,
+    mesh_file_name: str,
+    processes: int,
+    nodes: int,
+    cpus_per_process: int,
+    wall_time: str,
+) -> dict[str, int | str]:
+    return {
+        "script": "neso",
+        "neso_solver": solver,
+        "neso_conditions_file": conditions_file_name,
+        "neso_mesh_file": mesh_file_name,
+        # FabSim convention is to use 'cores' to set number of MPI processes
+        "cores": processes,
+        "nodes": nodes,
+        "corespernode": processes // nodes,
+        "cpuspertask": cpus_per_process,
+        "job_wall_time": wall_time,
+    }
+
+
 @fab.task
 @fab.load_plugin_env_vars("FabNESO")
 def neso(
@@ -27,6 +92,10 @@ def neso(
     solver: str = "Electrostatic2D3V",
     conditions_file_name: str = "conditions.xml",
     mesh_file_name: str = "mesh.xml",
+    processes: str | int = 4,
+    nodes: str | int = 1,
+    cpus_per_process: str | int = 1,
+    wall_time: str = "00:15:00",
     **parameter_overrides: str,
 ) -> None:
     """
@@ -37,10 +106,20 @@ def neso(
         solver: Which NESO solver to use.
         conditions_file_name: Name of conditions XML file in configuration directory.
         mesh_file_name: Name of mesh XML in configuration directory.
+        processes: Number of processes to run on.
+        nodes: Number of nodes to run on. Only applicable when running on a multi-node
+            system.
+        cpus_per_process: Number of processing units to use per process. Only
+            applicable when running on a multi-node system.
+        wall_time: Maximum time to allow job to run for. Only applicable when submitting
+            to a job scheduler.
         **parameter_overrides: Additional keyword arguments will be passed to
             ``FabNESO.ensemble_tools.edit_parameters`` to create a temporary conditions
             file with these parameter vaues overriden.
     """
+    processes, nodes, cpus_per_process, wall_time = _check_and_process_resource_args(
+        processes, nodes, cpus_per_process, wall_time
+    )
     # Use a temporary directory context so that we can handle parameter inputs
     # from the command line
     original_config_path = Path(fab.find_config_file_path(config))
@@ -65,12 +144,15 @@ def neso(
         fab.with_config(config)
         fab.execute(fab.put_configs, config)
         fab.job(
-            {
-                "script": "neso",
-                "neso_solver": solver,
-                "neso_conditions_file": conditions_file_name,
-                "neso_mesh_file": mesh_file_name,
-            }
+            _create_job_args_dict(
+                solver,
+                conditions_file_name,
+                mesh_file_name,
+                processes,
+                nodes,
+                cpus_per_process,
+                wall_time,
+            )
         )
 
 
@@ -81,6 +163,10 @@ def neso_ensemble(
     solver: str = "Electrostatic2D3V",
     conditions_file_name: str = "conditions.xml",
     mesh_file_name: str = "mesh.xml",
+    processes: int = 4,
+    nodes: int = 1,
+    cpus_per_process: int = 1,
+    wall_time: str = "00:15:00",
 ) -> None:
     """
     Run ensemble of NESO solver instances.
@@ -90,16 +176,29 @@ def neso_ensemble(
         solver: Which NESO solver to use.
         conditions_file_name: Name of conditions XML file in configuration directory.
         mesh_file_name: Name of mesh XML in configuration directory.
+        processes: Number of processes to run each job in ensemble on.
+        nodes: Number of nodes to run each job in ensemble on. Only applicable when
+            running on a multi-node system.
+        cpus_per_process: Number of processing units to use per process for each job in
+            ensemble. Only applicable when running on a multi-node system.
+        wall_time: Maximum time to allow each job in ensemble to run for. Only
+            applicable when submitting to a job scheduler.
     """
+    processes, nodes, cpus_per_process, wall_time = _check_and_process_resource_args(
+        processes, nodes, cpus_per_process, wall_time
+    )
     path_to_config = fab.find_config_file_path(config)
     sweep_dir = str(Path(path_to_config) / "SWEEP")
     fab.update_environment(
-        {
-            "script": "neso",
-            "neso_solver": solver,
-            "neso_conditions_file": conditions_file_name,
-            "neso_mesh_file": mesh_file_name,
-        }
+        _create_job_args_dict(
+            solver,
+            conditions_file_name,
+            mesh_file_name,
+            processes,
+            nodes,
+            cpus_per_process,
+            wall_time,
+        )
     )
     fab.with_config(config)
     fab.run_ensemble(config, sweep_dir)

--- a/FabNESO/tasks.py
+++ b/FabNESO/tasks.py
@@ -106,7 +106,7 @@ def neso(
         solver: Which NESO solver to use.
         conditions_file_name: Name of conditions XML file in configuration directory.
         mesh_file_name: Name of mesh XML in configuration directory.
-        processes: Number of processes to run on.
+        processes: Number of processes to run.
         nodes: Number of nodes to run on. Only applicable when running on a multi-node
             system.
         cpus_per_process: Number of processing units to use per process. Only


### PR DESCRIPTION
Adds arguments `processes`, `nodes`, `cpus_per_process` and `wall_time` to both `neso` and `neso_ensemble` tasks to allow setting respectively number of processes to run job on, number of nodes to run processes over (on multi-node systems), number of processing units per process and maximum wall clock time (on systems with a job scheduler). Some basic checking that passed arguments are sensible is performed and they are translated to corresponding FabSim environment variable names which are used to set options in run command / scheduler job submission script. 