### PR TITLE
Add polynomial chaos expansion ensemble + analysis tasks

### DIFF
--- a/FabNESO/__init__.py
+++ b/FabNESO/__init__.py
@@ -1,9 +1,23 @@
 """Neptune Exploratory SOftware (NESO) plugin for FabSim3."""
 
 try:
-    from .tasks import neso, neso_ensemble, neso_vbmc, neso_write_field
+    from .tasks import (
+        neso,
+        neso_ensemble,
+        neso_pce_analysis,
+        neso_pce_ensemble,
+        neso_vbmc,
+        neso_write_field,
+    )
 
-    __all__ = ["neso", "neso_ensemble", "neso_vbmc", "neso_write_field"]
+    __all__ = [
+        "neso",
+        "neso_ensemble",
+        "neso_vbmc",
+        "neso_write_field",
+        "neso_pce_ensemble",
+        "neso_pce_analysis",
+    ]
 
 except ImportError:
     import warnings

--- a/config_files/2Din3D-hw/extract_outputs.py
+++ b/config_files/2Din3D-hw/extract_outputs.py
@@ -1,0 +1,29 @@
+"""Extract energy and enstrophy values from CSV file and output to JSON file."""
+
+import argparse
+import json
+from pathlib import Path
+
+import pandas as pd
+
+
+def extract_outputs(results_directory: str) -> dict[str, list[float]]:
+    """Extract energy and enstrophy values from CSV file."""
+    growth_rates_dataframe = pd.read_csv(Path(results_directory) / "growth_rates.csv")
+    return {col: growth_rates_dataframe[col].to_list() for col in ("E", "W")}
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "results_directory",
+        type=Path,
+        help="Directory solver outputs were written to",
+    )
+    parser.add_argument(
+        "output_file", type=Path, help="Path to write JSON output file to"
+    )
+    args = parser.parse_args()
+    outputs = extract_outputs(args.results_directory)
+    with args.output_file.open("w") as f:
+        json.dump(outputs, f)

--- a/config_files/two_stream/extract_outputs.py
+++ b/config_files/two_stream/extract_outputs.py
@@ -1,0 +1,43 @@
+""""Extract line field derivatives at final time from HDF5 file and output to JSON."""
+
+import argparse
+import json
+from pathlib import Path
+
+import h5py
+
+
+def _get_step_keys(hdf5_file: h5py.File) -> list[str]:
+    """Get ordered list of step keys."""
+    return sorted(hdf5_file.keys(), key=lambda k: int(k.split("#")[-1]))
+
+
+def extract_outputs(results_directory: str) -> dict[str, list[float]]:
+    """Extract line field derivatives at final time from HDF5 file."""
+    hdf5_file_path = (
+        Path(results_directory)
+        / "Electrostatic2D3V_line_field_deriv_evaluations.h5part"
+    )
+    with h5py.File(hdf5_file_path, "r") as hdf5_file:
+        step_keys = _get_step_keys(hdf5_file)
+        last_step_key = step_keys[-1]
+        return {
+            "x": list(hdf5_file[last_step_key]["x"]),
+            "phi": list(hdf5_file[last_step_key]["FIELD_EVALUATION_0"]),
+        }
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "results_directory",
+        type=Path,
+        help="Directory solver outputs were written to",
+    )
+    parser.add_argument(
+        "output_file", type=Path, help="Path to write JSON output file to"
+    )
+    args = parser.parse_args()
+    outputs = extract_outputs(args.results_directory)
+    with args.output_file.open("w") as f:
+        json.dump(outputs, f)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-"""Configuration file for the Sphinx documentation builder."""  # noqa: INP001
+"""Configuration file for the Sphinx documentation builder."""
 
 from importlib.metadata import version as get_version
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ ignore = [
     "D212", # multi-line-summary-first-line
     "D407", # removed dashes lines under sections
     "D417", # argument description in docstring (unreliable)
+    "INP001", # implicit-namespace-package - allow due to FabSim3 packaging conventions
     "ISC001", # simplify implicit str concatenation (ruff-format recommended)
     "N999", # invalid-module-name - follow FabSim3 convention of CamelCase plugin names
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 h5py>=3.10.0
 PyVBMC>=1.0.1
+easyvvuq>=1.2
+chaospy>=4.3.2
+pandas>=2.0


### PR DESCRIPTION
Resolves #5 

An alternative approach to that proposed in #43, this doesn't use the whole EasyVVUQ campaign infrastructure, only the components necessary for computing a polynomial chaos expansion (PCE) based analysis of NESO simulator outputs, while reusing as much of the existing infrastructure in the FabNESO for orchestrating running jobs and updating parameters in condition files as possible. Two tasks are added, one `neso_pce_ensemble` for running the ensemble of jobs corresponding to the quadrature points in the parameter space required to estimate the PCE coefficients, and a second `neso_pce_analysis` for taking the run outputs from `neso_pce_ensemble` and computing the PCE coefficients, with the resulting analysis results allowing computation of statistics of the solver outputs and construction of a surrogate model.